### PR TITLE
perf(exhentai): tweak request time for restart a connection

### DIFF
--- a/server/resource/server.toml
+++ b/server/resource/server.toml
@@ -7,6 +7,7 @@ winChromePath = 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.ex
 linuxChromePath = '/opt/google/chrome/chrome'
 waitTime = 1000
 waitTimeAfterError = 10000
+requestTime = 90000
 maxPageIndex = 40
 downloadPath = 'exhentai'
 winProxy = 'http://127.0.0.1:1080'

--- a/server/utils/exhentai.ts
+++ b/server/utils/exhentai.ts
@@ -1,9 +1,10 @@
 import { joinWithRootPath, readJsonFile } from './common';
 import fs from 'fs-extra';
-import path from 'path';
+import path, { dirname, join } from 'path';
+import glob from 'glob';
 import { getTargetResource } from './resource';
 
-const { listInfoPath } = getTargetResource('server').exhentai;
+const { listInfoPath, downloadPath } = getTargetResource('server').exhentai;
 
 export const getLatestListFileName = () => {
   const infoPath = joinWithRootPath(listInfoPath);
@@ -46,3 +47,14 @@ export const getBaseNameOfImage = (dir: string) =>
     .readdirSync(joinWithRootPath(dir))
     .filter(f => path.extname(f) !== 'json')
     .map(f => path.basename(f, '.jpg'));
+
+export const getEmptyRestDetailUrlInfo = () =>
+  glob
+    .sync(joinWithRootPath(downloadPath) + '/**/restDetailUrls.json')
+    .filter(item => {
+      const dirName = dirname(item);
+      if (!fs.existsSync(join(dirName, 'detailImageUrls.json'))) {
+        return true;
+      }
+      return false;
+    });


### PR DESCRIPTION
- 本来增加了个同步：根据 `restDetailUrls.json` 下载所有图片，但想了想发现几乎用不到这个，又不想直接删了，就传上来。反正不影响其他功能
- 重新请求时间增加到 90s